### PR TITLE
Added support for subdirectory and version overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Default to `master`
 $ ern publish-container --containerPath [pathToContainer] -p git -u [gitRepoUrl] -v [containerVersion] ---platform [android|ios] -e '{"branch":"[branch_name]"}'
 ```
 
+- `subdir` : The name of the subdirectory you want to publish to
+
+```bash
+$ ern publish-container --containerPath [pathToContainer] -p git -u [gitRepoUrl] -v [containerVersion] ---platform [android|ios] -e '{"subdir":"[subdirectory]"}'
+```
+
+- `allowVersionOverwrite` : A boolean flag to allow overwriting the version (tag). Defaults to false.
+
+```bash
+$ ern publish-container --containerPath [pathToContainer] -p git -u [gitRepoUrl] -v [containerVersion] ---platform [android|ios] -e '{"allowVersionOverwrite": true}'
+```
+
 ### **With Cauldron**
 
 **Required**


### PR DESCRIPTION
We started recently using `ern` and we feel like the current usage requires to create a lot of git repositories and that it is not always practical.
For the published container especially we see it as an eventual problem as we generate repos which people might be tempted to modify even though they should not.
Thus we thought a bit about it and came up with an idea: What if we could have a branch on our repo where the containers live...
Then we have a problem with the tag, we want to keep it consistent between android and iOs and if we want to have only one repo, that wouldn't be possible with the current version of the container, as a tag is a unique identifier for the whole repository.

Thus here is a proposal PR to add the following to the git publisher to enable this workflow:
- Support for an optional `subdir` argument. It is a path to the subdirectory where to put the container project, so that both android and iOs folders can leave on the same repo.
- Support for an optional `allowVersionOverwrite` option, allowing to overwrite the version tag (as we want the same tag for android and iOs, but we still have to publish them separately)